### PR TITLE
fixed newGame context, removed players + newGame local storage

### DIFF
--- a/client/src/components/new game/NewGame.js
+++ b/client/src/components/new game/NewGame.js
@@ -50,28 +50,13 @@ const NewGame = (props) => {
 
   let { id } = useParams();
 
-  useEffect(() => {
-    if (localStorage.getItem("newGame")) {
-      if (id !== localStorage.getItem("newGame").gameId) {
-        setNewGame((prevState) => ({
-          ...prevState,
-          step: 1,
-          gameId: id,
-        }));
-        localStorage.setItem("newGame", JSON.stringify(newGame));
-      }
-    }
-  }, []);
+  // Goes back to the step of the host when page refreshes
+  useEffect(() => window.localStorage.setItem("newGame", newGame), [newGame]);
 
   const resetNewGame = async () => {
     try {
       const getData = await axios.post("/create-game");
-      await setNewGame((prevState) => ({
-        ...prevState,
-        step: 1,
-        hostId: localStorage.getItem("id"),
-        gameId: getData.data.game.id,
-      }));
+      await setNewGame(1);
       await props.value.history.push(String(getData.data.game.id));
     } catch (err) {
       console.log(err);
@@ -79,17 +64,13 @@ const NewGame = (props) => {
   };
 
   const nextStep = () => {
-    const { step } = newGame;
-    setNewGame((prevState) => ({
-      ...prevState,
-      step: step + 1,
-    }));
+    setNewGame((prevState) => prevState + 1);
   };
 
   //Sends Date to Start Game
   const startGame = async (e) => {
     try {
-      const setGame = (newGame, players, spyMaster) => {
+      const setGame = (players, spyMaster) => {
         let spyMasters = [spyMaster.blue, spyMaster.red];
 
         let playerAssign = players.map((player) => {
@@ -111,11 +92,12 @@ const NewGame = (props) => {
         });
 
         return {
-          gameId: newGame.gameId,
+          gameId: id,
           players: playerAssign,
         };
       };
-      const gameDetails = await setGame(newGame, players, spyMaster);
+      const gameDetails = await setGame(players, spyMaster);
+      console.log('emit-start-game', gameDetails)
       socket.emit("start-game", gameDetails);
     } catch (err) {
       console.log(err);
@@ -123,10 +105,7 @@ const NewGame = (props) => {
   };
 
   const newGameSteps = () => {
-    const { step } = newGame;
-    switch (step) {
-      // case 0:
-      //   return <NewGameLoading />;
+    switch (newGame) {
       case 1:
         return <StepOne />;
       case 2:
@@ -134,7 +113,12 @@ const NewGame = (props) => {
       case 3:
         return <StepThree />;
       default:
-        return <h2>Game Starts?</h2>;
+        return (
+          <h2>
+            Error. It is likely the New Game component is showing and it
+            shouldn't be.
+          </h2>
+        );
     }
   };
 
@@ -158,17 +142,13 @@ const NewGame = (props) => {
             alignItems="center"
           >
             <Box mx={2}>
-              {newGame.step < 3 ? (
+              {newGame < 3 ? (
                 <Button variant="contained" color="primary" onClick={nextStep}>
                   Next
                 </Button>
               ) : (
                 //Needs Logic here to initiate final role allocation.
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={startGame}
-                >
+                <Button variant="contained" color="primary" onClick={startGame}>
                   Create Game
                 </Button>
               )}

--- a/client/src/components/new game/WaitingRoom.js
+++ b/client/src/components/new game/WaitingRoom.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import StepTwo from "./step 2/StepTwo";
-import { useNewGame, useHostName } from "../../contexts/DataContext";
+import { useHostName } from "../../contexts/DataContext";
 import { useParams } from "react-router-dom";
 import {
   Container,
@@ -31,18 +31,9 @@ const useStyles = makeStyles((theme) =>
 
 const WaitingRoom = (props) => {
   const classes = useStyles();
-  const [newGame, setNewGame] = useNewGame();
   const [hostName] = useHostName();
-  let { id } = useParams();
 
   const userName = localStorage.getItem("name");
-
-  useEffect(() => {
-    setNewGame((prevState) => ({
-      ...prevState,
-      gameId: id,
-    }));
-  }, []);
 
   return (
     <Container maxWidth="md">

--- a/client/src/components/new game/step 1/LinkInvite.js
+++ b/client/src/components/new game/step 1/LinkInvite.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useNewGame } from "../../../contexts/DataContext";
+import { useParams } from "react-router-dom";
 import { Button, Typography, Box, Grid } from "@material-ui/core";
 import { makeStyles, createStyles } from "@material-ui/core/styles";
 import LinkIcon from "@material-ui/icons/Link";
@@ -21,7 +21,7 @@ const LinkInvite = (props) => {
   const classes = useStyles();
 
   //Holds Game ID to be copied and shared with other players
-  const [newGame] = useNewGame();
+  let { id } = useParams();
 
   const [copy, setCopy] = useState({
     value: "",
@@ -30,10 +30,10 @@ const LinkInvite = (props) => {
 
   useEffect(() => {
     setCopy({
-      value: `http://localhost:3000/${newGame.gameId}`,
+      value: `http://localhost:3000/${id}`,
       copied: false,
     });
-  }, [newGame]);
+  }, []);
 
   return (
     <>
@@ -44,7 +44,7 @@ const LinkInvite = (props) => {
             text={copy.value}
             onCopy={() =>
               setCopy({
-                value: `http://localhost:3000/${newGame.gameId}`,
+                value: `http://localhost:3000/${id}`,
                 copied: true,
               })
             }

--- a/client/src/components/new game/step 2/StepTwo.js
+++ b/client/src/components/new game/step 2/StepTwo.js
@@ -54,15 +54,12 @@ const StepTwo = (props) => {
   useEffect(()=>{
     socket.on("update-players", ({ game, errors }) => {
       console.log("updated players", game.players)
-      console.log(game.currentUser._id)
       setPlayers(game.players);
       setHostId(game.currentUser._id);
       setHostName(game.currentUser.name);
     });
   },[players]);
 
-  console.log('hostName', hostName)
-  console.log('hostId', hostId)
 
   const showPlayers = () => {
     return players.map((player, i) => {

--- a/client/src/components/new game/step 2/StepTwo.js
+++ b/client/src/components/new game/step 2/StepTwo.js
@@ -3,6 +3,7 @@ import {
   useNewGame,
   usePlayers,
   useHostName,
+  useHostId
 } from "../../../contexts/DataContext";
 import { useParams } from "react-router-dom";
 import {
@@ -27,9 +28,9 @@ const useStyles = makeStyles((theme) =>
 );
 
 const StepTwo = (props) => {
-  const [newGame] = useNewGame();
   const [players, setPlayers] = usePlayers();
   const [hostName, setHostName] = useHostName();
+  const [hostId, setHostId] = useHostId();
   let { id } = useParams();
 
   const classes = useStyles();
@@ -45,23 +46,23 @@ const StepTwo = (props) => {
     };
 
     if (id !== "") {
+      console.log('emit-join-match', data)
       socket.emit("join-game", data);
     }
-    //Shows players that have joined so far in game setup (Will be displayed in StepTwo.js)
-
-    // socket.on("update-players", ({ game, errors }) => {
-    //   setPlayers(game.players);
-    //   setHostName(game.currentUser.name);
-    // });
   }, []);
 
   useEffect(()=>{
     socket.on("update-players", ({ game, errors }) => {
       console.log("updated players", game.players)
+      console.log(game.currentUser._id)
       setPlayers(game.players);
+      setHostId(game.currentUser._id);
       setHostName(game.currentUser.name);
     });
   },[players]);
+
+  console.log('hostName', hostName)
+  console.log('hostId', hostId)
 
   const showPlayers = () => {
     return players.map((player, i) => {

--- a/client/src/contexts/DataContext.js
+++ b/client/src/contexts/DataContext.js
@@ -10,6 +10,8 @@ const SpyMasterContext = React.createContext();
 
 const HostNameContext = React.createContext();
 
+const HostIdContext = React.createContext();
+
 // Custom hook for Emails to be invited to game
 export function useEmails() {
   return useContext(EmailContext);
@@ -30,8 +32,14 @@ export function useSpyMaster() {
   return useContext(SpyMasterContext);
 }
 
+// Holds Host Name to display for Waiting Room.js
 export function useHostName() {
   return useContext(HostNameContext);
+}
+
+//Holds Host Id on Game Setup.js to determine if the user is a host.
+export function useHostId() {
+  return useContext(HostIdContext);
 }
 
 export function DataProvider({ children }) {
@@ -42,12 +50,10 @@ export function DataProvider({ children }) {
     setEmails,
   ]);
 
-  //Holds New Game Steps + Game Data
-  const [newGame, setNewGame] = useState({
-    step: 1,
-    gameId: "",
-    hostId: null,
-  });
+  //Holds New Game Steps for Host
+  const initialState = () =>
+    Number(window.localStorage.getItem("newGame") || null);
+  const [newGame, setNewGame] = useState(initialState);
 
   const providerNewGame = useMemo(() => [newGame, setNewGame], [
     newGame,
@@ -57,24 +63,10 @@ export function DataProvider({ children }) {
   //Holds Players who have accepted game invite
   const [players, setPlayers] = useState([]);
 
-  //Default State (for testing)
-  // const [players, setPlayers] = useState([
-  //   { name: "Karl", id: "1" },
-  //   { name: "Jorawar", id: "2" },
-  //   { name: "Nicholas", id: "3" },
-  //   { name: "Bonnie", id: "4" },
-  //   { name: "Henry", id: "5" },
-  //   { name: "Joy", id: "6" },
-  // ]);
-
   const providerPlayers = useMemo(() => [players, setPlayers], [
     players,
     setPlayers,
   ]);
-
-  useEffect(() => {
-    localStorage.setItem("players", JSON.stringify(players));
-  }, [players]);
 
   //Holds SpyMaster
   const [spyMaster, setSpyMaster] = useState({ blue: "", red: "" });
@@ -91,13 +83,21 @@ export function DataProvider({ children }) {
     setHostName,
   ]);
 
+  const [hostId, setHostId] = useState("");
+  const providerHostId = useMemo(() => [hostId, setHostId], [
+    hostName,
+    setHostId,
+  ]);
+
   return (
     <NewGameContext.Provider value={providerNewGame}>
       <EmailContext.Provider value={providerEmails}>
         <PlayersContext.Provider value={providerPlayers}>
           <SpyMasterContext.Provider value={providerSpyMaster}>
             <HostNameContext.Provider value={providerHostName}>
-              {children}
+              <HostIdContext.Provider value={providerHostId}>
+                {children}
+              </HostIdContext.Provider>
             </HostNameContext.Provider>
           </SpyMasterContext.Provider>
         </PlayersContext.Provider>

--- a/client/src/pages/GameSetup.js
+++ b/client/src/pages/GameSetup.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useGameStatus } from "../contexts/GameContext";
-import { useNewGame, usePlayers } from "../contexts/DataContext";
+import { usePlayers, useHostId } from "../contexts/DataContext";
 import NewGame from "../components/new game/NewGame";
 import WaitingRoom from "../components/new game/WaitingRoom";
 import Game from "../components/Game";
@@ -8,31 +8,19 @@ import socket from "../socket";
 
 const GameSetup = (props) => {
   const [gameStatus, setGameStatus] = useGameStatus();
-  const [newGame, setNewGame] = useNewGame();
   const [players, setPlayers] = usePlayers();
-
-  const gameData = localStorage.getItem("newGame");
+  const [hostId, setHostId] = useHostId();
 
   useEffect(() => {
-    if (gameData) {
-      // setNewGame(JSON.parse(localStorage.getItem("newGame")));
-      setPlayers(JSON.parse(localStorage.getItem("players")));
-    }
-
     //Shows players now assigned on teams and roles, ALSO - change gameStatus now === "running"
     socket.on("update-roles", (game) => {
       console.log("socket-on-update-roles", game);
       setGameStatus(game.gameStatus);
     });
-  }, [gameData, setGameStatus, setNewGame, setPlayers]);
-
-  // Stores New Game Info to Local Storage
-  useEffect(() => {
-    localStorage.setItem("newGame", JSON.stringify(newGame));
-  }, [newGame]);
+  }, [setGameStatus]);
 
   const gameJourney = () => {
-    if (localStorage.getItem("id") === newGame.hostId) {
+    if (localStorage.getItem("id") === hostId) {
       return <NewGame value={props} />;
     } else {
       return <WaitingRoom value={props} />;

--- a/client/src/pages/Landing.js
+++ b/client/src/pages/Landing.js
@@ -37,8 +37,7 @@ const Landing = (props) => {
 
   //Holds Game ID + Template for Passing Roles to Server
 
-  const NewGameContext = useNewGame();
-  const [newGame, setNewGame] = NewGameContext;
+  const [newGame, setNewGame] = useNewGame();
   const [openDialog, setOpenDialog] = useState(false);
   const [error, setError] = useState("");
 
@@ -57,12 +56,7 @@ const Landing = (props) => {
         // localStorage.clear();
         return null;
       }
-      await setNewGame((prevState) => ({
-        ...prevState,
-        step: 1,
-        hostId: localStorage.getItem("id"),
-        gameId: getData.data.game.id,
-      }));
+      await setNewGame(1);
       await props.history.push(String(getData.data.game.id));
     } catch (err) {
       console.log(err);

--- a/server/app.js
+++ b/server/app.js
@@ -13,7 +13,6 @@ const config = require("./config");
 const gameRouter = require("./routes/game");
 const authRouter = require("./routes/auth");
 const User = require("./models/User");
-const gameSocket = require("./gameSocket");
 
 // app configuration
 var app = express();


### PR DESCRIPTION
@chumnend @jorawarSinghNijjar 

The new game process was frequently crashing due to unnecessary rerenders. 

I was able to change the newGame context so that it only includes which step the host is on.

I also removed matchId and the players array from local storage, which seems to make things run smoother. 

Let me know what you think! 