### PR TITLE
Added ability to change turns

### DIFF
--- a/client/src/components/GameBar/styles.js
+++ b/client/src/components/GameBar/styles.js
@@ -44,7 +44,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    color: props.urrentTurn === "red" ? theme.white : theme.red.medium,
+    color: props.currentTurn === "red" ? theme.white : theme.red.medium,
     background: props.currentTurn === "red" ? theme.red.medium : "none",
     borderRadius: "5px",
     "& h3": {

--- a/client/src/components/Messenger/Messenger.js
+++ b/client/src/components/Messenger/Messenger.js
@@ -65,10 +65,11 @@ const Messenger = (props) => {
         />
         {props.isSpyMaster && (
           <Button
-            type="submit"
             variant="contained"
             color="primary"
             size="large"
+            onClick={props.changeTurn}
+            disabled={!props.isTurn}
           >
             Done
           </Button>
@@ -90,6 +91,7 @@ Messenger.propTypes = {
   name: PropTypes.string,
   isSpyMaster: PropTypes.bool,
   isTurn: PropTypes.bool,
+  changeTurn: PropTypes.func,
 };
 
 export default Messenger;

--- a/client/src/pages/Game/Game.js
+++ b/client/src/pages/Game/Game.js
@@ -87,7 +87,7 @@ const Game = (props) => {
 
   const changeTurn = () => {
     socket.emit("change-turn", { gameId });
-  }
+  };
 
   return (
     <div className={classes.Game}>

--- a/client/src/pages/Game/Game.js
+++ b/client/src/pages/Game/Game.js
@@ -21,8 +21,8 @@ const Game = (props) => {
 
   useEffect(() => {
     // join the match
-    socket.emit("join", { gameId, token }, (recv) => {
-      console.log(recv);
+    socket.emit("init-game", { gameId, token }, (recv) => {
+      console.log("Game State:", recv);
 
       setName(recv.name);
       setMessages(recv.history);
@@ -53,12 +53,15 @@ const Game = (props) => {
       setCurrentTurn(recv.state.turn);
     });
 
-    socket.on("message", (recv) => {
-      // update message list
-      setMessages((prevMessages) => [...prevMessages, recv]);
+    socket.on("update-game", (recv) => {
+      console.log("Updated Game State:", recv);
+
+      // set current state of the game
+      setBoard(recv.board);
+      setCurrentTurn(recv.turn);
     });
 
-    socket.on("alert", (recv) => {
+    socket.on("new-message", (recv) => {
       setMessages((prevMessages) => [...prevMessages, recv]);
     });
 
@@ -82,6 +85,10 @@ const Game = (props) => {
     });
   };
 
+  const changeTurn = () => {
+    socket.emit("change-turn", { gameId });
+  }
+
   return (
     <div className={classes.Game}>
       <GameBar
@@ -96,6 +103,7 @@ const Game = (props) => {
           name={name}
           isSpyMaster={isSpyMaster}
           isTurn={team === currentTurn}
+          changeTurn={changeTurn}
         />
         <Board board={board} isSpyMaster={isSpyMaster} />
       </div>

--- a/server/socket.js
+++ b/server/socket.js
@@ -100,7 +100,7 @@ module.exports = (server) => {
       }
     });
 
-    socket.on("join", (recv, fn) => {
+    socket.on("init-game", (recv, fn) => {
       const { gameId, token } = recv;
 
       try {
@@ -135,7 +135,7 @@ module.exports = (server) => {
         };
 
         roomDetails[recv.gameId].history.push(alert);
-        socket.to(recv.gameId).broadcast.emit("alert", alert);
+        socket.to(recv.gameId).broadcast.emit("new-message", alert);
 
         // return assigned name and chat history
         fn({
@@ -162,7 +162,7 @@ module.exports = (server) => {
       roomDetails[gameId].history.push(msgData);
 
       // update other clients with the message
-      io.to(gameId).emit("message", msgData);
+      io.to(gameId).emit("new-message", msgData);
     });
 
     // Socket listener for next move
@@ -171,6 +171,15 @@ module.exports = (server) => {
 
       const currentGame = allGames.getAllGames().get(parseInt(gameId));
       currentGame.pickCard(playerId, cardIndex); // Result of the move would be in console for now
+    });
+
+    socket.on("change-turn", (recv) => {
+      const { gameId } = recv;
+
+      const currentGame = allGames.getAllGames().get(parseInt(gameId));
+      currentGame.changeTurn();
+
+      io.to(gameId).emit("update-game", currentGame);
     });
 
     // Clean up when a user disconnects


### PR DESCRIPTION
Implemented ability for Spymasters to end thier teams turn.

- renamed "join" to "init-game"
- removed "alert" and "message" event usage in backend and replaced with "new-message" event
- added "change-turn" event in backend to cause turn to change
- added "update-game" event in client to update the game state for each client