### PR TITLE
Set game status on joining match

### DIFF
--- a/client/src/components/new game/step 2/StepTwo.js
+++ b/client/src/components/new game/step 2/StepTwo.js
@@ -4,6 +4,7 @@ import {
   useHostName,
   useHostId,
 } from "../../../contexts/DataContext";
+import { useGameStatus } from "../../../contexts/GameContext";
 import { useParams } from "react-router-dom";
 import {
   Box,
@@ -24,6 +25,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const StepTwo = (props) => {
+  const [, setGameStatus] = useGameStatus();
   const [players, setPlayers] = usePlayers();
   const [, setHostName] = useHostName();
   const [, setHostId] = useHostId();
@@ -43,6 +45,7 @@ const StepTwo = (props) => {
 
     socket.on("update-players", (game) => {
       console.log("Updated players:", game.players);
+      setGameStatus(game.gameStatus);
       setPlayers(game.players);
       setHostId(game.host._id);
       setHostName(game.host.name);


### PR DESCRIPTION
Clicking refresh while in a game will sometimes bring you back to the game setup page.

This will help fix things - it sets the gameStatus in case just the game setup components mount. 

Right now the initial game state is "setup", which is probably the core issue of this happening. Ideally, we would have some type of board loading component, but this is more of a quick fix for now. 